### PR TITLE
fix(ci): Remove invalid Docker tag format for PR builds

### DIFF
--- a/.github/workflows/build-auth-server.yml
+++ b/.github/workflows/build-auth-server.yml
@@ -68,8 +68,8 @@ jobs:
             type=ref,event=branch
             # Tag with PR number for pull requests
             type=ref,event=pr
-            # Tag with git SHA for all builds
-            type=sha,prefix={{branch}}-
+            # Tag with git SHA (simple format)
+            type=sha
             # Always tag as 'latest' for every successful build
             type=raw,value=latest
             # Tag with version for tags (if using git tags)


### PR DESCRIPTION
The SHA tag with branch prefix was creating invalid tags like ':-2da6416' for PR builds where branch name is empty. Switch to simple SHA tagging.

Fixes Docker build error: invalid reference format

🤖 Generated with [Claude Code](https://claude.ai/code)